### PR TITLE
removed reference to delaunay triangulation

### DIFF
--- a/THIRD_PARTY
+++ b/THIRD_PARTY
@@ -29,42 +29,22 @@ derived source contained in TIN Terrain:
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-    
-- Delaunay Triangulation algorithm from OSM Wave by Per Liedman in files:
-    src/Delaunay.cpp
-    include/tngrnd/Delaunay.h
-    
-    The original files are from:
-    https://github.com/perliedman/osmwave
-    
-    The original license is:
-    ISC License
-
-    Copyright (c) 2016, Per Liedman <per@liedman.net>
-
-    Permission to use, copy, modify, and/or distribute this software for any
-    purpose with or without fee is hereby granted, provided that the above
-    copyright notice and this permission notice appear in all copies.
-
-    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 - Delaunay Triangulation algorithm from Mapbox's Delaunator JS Library ported to C++
     src/Delaunator.cpp
-    src/CircularList.cpp
-    include/delaunay/Delaunator.h
-    include/delaunay/CircularList.h
-    
+    include/delaunator_cpp/Delaunator.h
+
     The original files are from:
     https://github.com/mapbox/delaunator
-    
+
     The original license is:
     ISC License
+
+    The cpp port that this project is based on:
+    https://github.com/delfrrr/delaunator-cpp
+    
+    License of the cpp port is:
+    MIT License
 
     Copyright (c) 2017, Mapbox
 


### PR DESCRIPTION
- removed reference to delaunay triangulation as this is no longer part of project
- updated reference to delaunator 
    -  added ref to cpp port and licence



