### PR TITLE
Make compiler happy again by using fabs on double instead of abs

### DIFF
--- a/include/tntn/Mesh.h
+++ b/include/tntn/Mesh.h
@@ -58,7 +58,7 @@ class Mesh
     void get_bbox(BBox3D& bbox) const;
 
     bool check_tin_properties() const;
-    
+
     bool is_square() const;
     bool check_for_holes_in_square_mesh() const;
 

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -447,65 +447,64 @@ bool Mesh::is_square() const
 {
     BBox3D bb3d;
     get_bbox(bb3d);
-    
-    
+
     double dx = bb3d.max.x - bb3d.min.x;
     double dy = bb3d.max.y - bb3d.min.y;
-    
+
     TNTN_ASSERT(dx > 0);
     TNTN_ASSERT(dy > 0);
-    
-    double eps = ( dx + dy ) / 20000.0;
-    
+
+    double eps = (dx + dy) / 20000.0;
+
     // double check assumption that mesh is square and aligned with bb
     // see if we have vertex points at all 4 corners of bb
-    
+
     bool corners_exist[4];
-    for(int i=0; i < 4; i++)
+    for(int i = 0; i < 4; i++)
     {
         corners_exist[i] = false;
     }
-    
-    for(const Vertex &v : m_vertices)
+
+    for(const Vertex& v : m_vertices)
     {
         if(std::abs(v.x - bb3d.min.x) < eps && std::abs(v.y - bb3d.min.y) < eps)
         {
             corners_exist[0] = true;
         }
-        
+
         if(std::abs(v.x - bb3d.max.x) < eps && std::abs(v.y - bb3d.max.y) < eps)
         {
             corners_exist[1] = true;
         }
-        
+
         if(std::abs(v.x - bb3d.max.x) < eps && std::abs(v.y - bb3d.min.y) < eps)
         {
             corners_exist[2] = true;
         }
-        
+
         if(std::abs(v.x - bb3d.min.x) < eps && std::abs(v.y - bb3d.max.y) < eps)
         {
             corners_exist[3] = true;
         }
-        
-        int true_count=0;
-        for(int i=0; i < 4; i++)
+
+        int true_count = 0;
+        for(int i = 0; i < 4; i++)
         {
             if(corners_exist[i])
             {
                 true_count++;
             }
         }
-        
+
         if(true_count == 4)
         {
             return true;
         }
     }
-    
+
     return false;
 }
-    
+
 /**
  checks if mesh has holes in it
  will only work for meshes where the convex hull is square
@@ -522,41 +521,45 @@ bool Mesh::check_for_holes_in_square_mesh() const
     // 2. sum area of all triangles
     // 3. comapre 1 & 2 to see if they are equal
     // assumptions: mesh area (convex hull) is square and can be simply computed from bb / x y min max points
-    
+
     // get bounding box
     BBox3D bb3d;
     this->get_bbox(bb3d);
 
     double dx = bb3d.max.x - bb3d.min.x;
     double dy = bb3d.max.y - bb3d.min.y;
-    
+
     TNTN_ASSERT(dx > 0);
     TNTN_ASSERT(dy > 0);
-    
-    double eps = ( dx + dy ) / 20000.0;
-   
+
+    double eps = (dx + dy) / 20000.0;
+
     if(is_square())
     {
         TNTN_LOG_DEBUG("mesh is square - checking for holes");
-        
-        double area_bb      = dx*dy;
+
+        double area_bb = dx * dy;
         double area_tri_sum = 0;
-        
-        for(const Face &f : m_faces)
+
+        for(const Face& f : m_faces)
         {
-            const Vertex& v1 =  m_vertices[f[0]];
-            const Vertex& v2 =  m_vertices[f[1]];
-            const Vertex& v3 =  m_vertices[f[2]];
-            
+            const Vertex& v1 = m_vertices[f[0]];
+            const Vertex& v2 = m_vertices[f[1]];
+            const Vertex& v3 = m_vertices[f[2]];
+
             //area of triangle
-            double area_tri = 0.5 * std::abs( (v2.x-v1.x) * (v3.y-v1.y) - (v3.x-v1.x) * (v2.y-v1.y) );
-            
+            double area_tri =
+                0.5 * std::abs((v2.x - v1.x) * (v3.y - v1.y) - (v3.x - v1.x) * (v2.y - v1.y));
+
             area_tri_sum += area_tri;
         }
-        
+
         if(std::abs(area_tri_sum - area_bb) > eps)
         {
-            TNTN_LOG_DEBUG("mesh has holes. area of bounding box {} area of all triangles combined {}",area_bb,area_tri_sum);
+            TNTN_LOG_DEBUG(
+                "mesh has holes. area of bounding box {} area of all triangles combined {}",
+                area_bb,
+                area_tri_sum);
             return true;
         }
         else
@@ -695,14 +698,14 @@ bool Mesh::check_tin_properties() const
         }
     }
 #endif
-    
+
     // IF the mesh convex hull is square
     // this function will detect holes
     if(check_for_holes_in_square_mesh())
     {
         return false;
     }
-    
+
     TNTN_LOG_DEBUG("mesh is a regular/propper TIN");
     return true;
 }

--- a/src/Mesh2Raster.cpp
+++ b/src/Mesh2Raster.cpp
@@ -219,7 +219,7 @@ RasterDouble Mesh2Raster::rasterise(
         }
         tcount++;
     }
-    
+
 #ifdef TNTN_DEBUG
     // count empty pixels
     // i.e. where rendere hasn't been able to add height

--- a/src/RasterIO.cpp
+++ b/src/RasterIO.cpp
@@ -357,7 +357,7 @@ bool load_raster_file(const std::string& file_name,
         println("input raster file must be in EPSG:3857 (Web Mercator) format");
         println("you can reproject raster terrain using GDAL");
         println("as follows: 'gdalwarp -t_srs EPSG:3857 input.tif output.tif'");
-        
+
         return false;
     }
 

--- a/src/RasterIO.cpp
+++ b/src/RasterIO.cpp
@@ -265,11 +265,11 @@ static bool get_transformation_matrix(GDALDataset* dataset, TransformationMatrix
         return false;
     }
 
-    if(abs(gt.scale_x) != abs(gt.scale_y))
+    if(fabs(gt.scale_x) != fabs(gt.scale_y))
     {
         TNTN_LOG_ERROR("Can not process rasters with non square pixels ({}x{})",
-                       abs(gt.scale_x),
-                       abs(gt.scale_y));
+                       fabs(gt.scale_x),
+                       fabs(gt.scale_y));
         return false;
     }
 
@@ -381,7 +381,7 @@ bool load_raster_file(const std::string& file_name,
     int raster_width = raster_band->GetXSize();
     int raster_height = raster_band->GetYSize();
 
-    target_raster.set_cell_size(abs(gt.scale_x));
+    target_raster.set_cell_size(fabs(gt.scale_x));
     target_raster.allocate(raster_width, raster_height);
     target_raster.set_no_data_value(raster_band->GetNoDataValue());
 

--- a/src/RasterOverviews.cpp
+++ b/src/RasterOverviews.cpp
@@ -46,7 +46,7 @@ int RasterOverviews::guess_min_zoom_level(int max_zoom_level)
 
 void RasterOverviews::compute_zoom_levels()
 {
-    m_estimated_max_zoom = guess_max_zoom_level(abs(m_base_raster->get_cell_size()));
+    m_estimated_max_zoom = guess_max_zoom_level(fabs(m_base_raster->get_cell_size()));
     m_estimated_min_zoom = guess_min_zoom_level(m_estimated_max_zoom);
 
     if(m_min_zoom <= m_estimated_min_zoom)

--- a/src/SurfacePoints.cpp
+++ b/src/SurfacePoints.cpp
@@ -137,7 +137,7 @@ double SurfacePoints::find_non_zero_min_diff(const std::vector<double>& values,
 
         TNTN_LOG_TRACE("v: {:6}", v);
 
-        double d = abs(last - v);
+        double d = fabs(last - v);
         if(d > 0)
         {
             if(min_diff == 0)

--- a/src/TileMaker.cpp
+++ b/src/TileMaker.cpp
@@ -119,7 +119,7 @@ bool TileMaker::dumpTile(int tx, int ty, int zoom, const char* filename, MeshWri
     Mesh tileMesh;
     tileMesh.from_triangles(std::move(trianglesInTile));
     tileMesh.generate_decomposed();
-    
+
     return mesh_writer.write_mesh_to_file(filename, tileMesh, tileSpaceBbox);
 }
 

--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -139,18 +139,16 @@ static int subcommand_dem2tintiles(bool need_help,
     }
 
     const std::string meshing_method = local_varmap["method"].as<std::string>();
-    
-    
-    
+
     auto input_raster = std::make_unique<RasterDouble>();
 
     if(!load_raster_file(input_file.c_str(), *input_raster))
     {
         return false;
     }
-    
+
     double method_parameter = -1;
-    
+
     if("zemlya" == meshing_method || "terra" == meshing_method)
     {
         max_error = input_raster->get_cell_size();
@@ -159,12 +157,12 @@ static int subcommand_dem2tintiles(bool need_help,
             max_error_given = true;
             max_error = local_varmap["max-error"].as<double>();
         }
-        
+
         if(max_error < 0.0)
         {
             throw po::error("max-error must be positive");
         }
-        
+
         method_parameter = max_error;
     }
     else if("dense" == meshing_method)
@@ -174,7 +172,7 @@ static int subcommand_dem2tintiles(bool need_help,
         {
             step = local_varmap["step"].as<int>();
         }
-        
+
         method_parameter = step;
     }
 #if defined(TNTN_USE_ADDONS) && TNTN_USE_ADDONS
@@ -185,7 +183,7 @@ static int subcommand_dem2tintiles(bool need_help,
         {
             threshold = local_varmap["threshold"].as<double>();
         }
-        
+
         method_parameter = threshold;
     }
 #endif
@@ -290,12 +288,11 @@ static int subcommand_dem2tin(bool need_help,
 {
     TNTN_LOG_INFO("subcommand_dem2tin");
     po::options_description subdesc("dem2tin options");
-    
-    
+
 #if defined(TNTN_USE_ADDONS) && TNTN_USE_ADDONS
     std::cout << "works";
 #endif
-    
+
     // clang-format off
     subdesc.add_options()
         ("input", po::value<std::string>(), "input filename")
@@ -329,13 +326,16 @@ static int subcommand_dem2tin(bool need_help,
         println(
             "  terra     - implements a delaunay based triangulation with point selection using a fast greedy insert mechnism");
         println(
-                "    reference: Garland, Michael, and Paul S. Heckbert. \"Fast polygonal approximation of terrains and height fields.\" (1995).");
+            "    reference: Garland, Michael, and Paul S. Heckbert. \"Fast polygonal approximation of terrains and height fields.\" (1995).");
         println("    paper: https://mgarland.org/papers/scape.pdf");
         println("    and http://mgarland.org/archive/cmu/scape/terra.html");
         println("  zemlya    - hierarchical greedy insertion");
-        println("    reference: Zheng, Xianwei, et al. \"A VIRTUAL GLOBE-BASED MULTI-RESOLUTION TIN SURFACE MODELING AND VISUALIZETION METHOD.\" International Archives of the Photogrammetry, Remote Sensing & Spatial Information Sciences 41 (2016).");
-        println("    paper: https://www.int-arch-photogramm-remote-sens-spatial-inf-sci.net/XLI-B2/459/2016/isprs-archives-XLI-B2-459-2016.pdf");
-        println("  dense     - generates a simple mesh grid from the raster input by placing one vertex per pixel");
+        println(
+            "    reference: Zheng, Xianwei, et al. \"A VIRTUAL GLOBE-BASED MULTI-RESOLUTION TIN SURFACE MODELING AND VISUALIZETION METHOD.\" International Archives of the Photogrammetry, Remote Sensing & Spatial Information Sciences 41 (2016).");
+        println(
+            "    paper: https://www.int-arch-photogramm-remote-sens-spatial-inf-sci.net/XLI-B2/459/2016/isprs-archives-XLI-B2-459-2016.pdf");
+        println(
+            "  dense     - generates a simple mesh grid from the raster input by placing one vertex per pixel");
 #if defined(TNTN_USE_ADDONS) && TNTN_USE_ADDONS
         println("  curvature - sets points when curvature integral is larger than threshold");
 #endif
@@ -354,14 +354,14 @@ static int subcommand_dem2tin(bool need_help,
         throw po::error("no --output option given");
     }
 
-    const std::string   output_file               = local_varmap["output"].as<std::string>();
-    const std::string   output_file_format_str    = local_varmap["output-format"].as<std::string>();
-    const FileFormat    output_file_format        =
+    const std::string output_file = local_varmap["output"].as<std::string>();
+    const std::string output_file_format_str = local_varmap["output-format"].as<std::string>();
+    const FileFormat output_file_format =
         validate_output_format_for_mesh(output_file, output_file_format_str);
 
-    const std::string   method                    = local_varmap["method"].as<std::string>();
+    const std::string method = local_varmap["method"].as<std::string>();
 
-    auto                raster                    = std::make_unique<RasterDouble>();
+    auto raster = std::make_unique<RasterDouble>();
 
     // Import raster file without projection validation
     if(!load_raster_file(input_file, *raster, false))
@@ -369,13 +369,12 @@ static int subcommand_dem2tin(bool need_help,
         TNTN_LOG_ERROR("Unable to load input file, aborting");
         return false;
     }
-    
+
     TNTN_LOG_INFO("done");
 
     std::unique_ptr<Mesh> mesh;
 
     const auto t_start = std::chrono::high_resolution_clock::now();
-
 
     if(method == "terra" || method == "zemlya")
     {
@@ -384,7 +383,7 @@ static int subcommand_dem2tin(bool need_help,
         {
             max_error = local_varmap["max-error"].as<double>();
         }
-        
+
         if("terra" == method)
         {
             TNTN_LOG_INFO("performing terra meshing...");
@@ -403,7 +402,7 @@ static int subcommand_dem2tin(bool need_help,
         {
             step = local_varmap["step"].as<int>();
         }
-        
+
         TNTN_LOG_INFO("generating dense mesh grid ...");
         mesh = generate_tin_dense_quadwalk(*raster, step);
     }
@@ -414,14 +413,14 @@ static int subcommand_dem2tin(bool need_help,
         {
             throw po::error("no --threshold given, required for this method");
         }
-        
+
         double gradient_threshold = local_varmap["threshold"].as<double>();
-        
+
         if(gradient_threshold <= 0.0)
         {
             throw po::error("threshold must be larger than zero");
         }
-        
+
         TNTN_LOG_INFO("performing curverture integral meshing...");
         mesh = generate_tin_curvature(*raster, gradient_threshold);
     }
@@ -465,7 +464,7 @@ static int subcommand_dem2tin(bool need_help,
         TNTN_LOG_INFO("number of vertices: {}", mesh->vertices().distance());
     }
 
-    TNTN_LOG_INFO("writing mesh... ({})",output_file);
+    TNTN_LOG_INFO("writing mesh... ({})", output_file);
     if(!write_mesh_to_file(output_file.c_str(), *mesh, output_file_format))
     {
         TNTN_LOG_ERROR("error writing output file");

--- a/src/dem2tintiles_workflow.cpp
+++ b/src/dem2tintiles_workflow.cpp
@@ -111,7 +111,7 @@ bool create_tiles_for_zoom_level(const RasterDouble& dem,
         }
         else if(meshing_method == "zemlya")
         {
-            mesh = generate_tin_zemlya(std::move(raster_tile),  method_parameter);
+            mesh = generate_tin_zemlya(std::move(raster_tile), method_parameter);
         }
 #if defined(TNTN_USE_ADDONS) && TNTN_USE_ADDONS
         else if(meshing_method == "curvature")

--- a/test/src/Mesh_tests.cpp
+++ b/test/src/Mesh_tests.cpp
@@ -11,85 +11,84 @@ TEST_CASE("test detector for holes", "[tntn]")
 {
     std::vector<Vertex> vertices;
     std::vector<Face> faces;
-    
+
     vertices.push_back({0.0, 0.0, 0.0}); // 0
     vertices.push_back({1.0, 0.0, 0.0}); // 1
     vertices.push_back({1.0, 1.0, 0.0}); // 2
     vertices.push_back({0.0, 1.0, 0.0}); // 3
     vertices.push_back({0.5, 0.5, 0.0}); // 4
-    
+
     faces.push_back({{0, 4, 3}}); // t0
     faces.push_back({{1, 2, 4}}); // t1
     faces.push_back({{3, 4, 2}}); // t2
-    
+
     Mesh has_hole;
     has_hole.from_decomposed(std::move(vertices), std::move(faces));
     has_hole.generate_triangles();
-    
+
     CHECK(has_hole.poly_count() == 3);
     CHECK(has_hole.check_for_holes_in_square_mesh() == true);
-    
+
     vertices.clear();
     faces.clear();
-    
+
     vertices.push_back({0.0, 0.0, 0.0}); // 0
     vertices.push_back({1.0, 0.0, 0.0}); // 1
     vertices.push_back({1.0, 1.0, 0.0}); // 2
     vertices.push_back({0.0, 1.0, 0.0}); // 3
     vertices.push_back({0.5, 0.5, 0.0}); // 4
-    
+
     faces.push_back({{0, 4, 3}}); // t0
     faces.push_back({{1, 2, 4}}); // t1
     faces.push_back({{3, 4, 2}}); // t2
     faces.push_back({{0, 4, 1}}); // t3
-    
+
     Mesh has_no_hole;
     has_no_hole.from_decomposed(std::move(vertices), std::move(faces));
     has_no_hole.generate_triangles();
-    
+
     CHECK(has_no_hole.poly_count() == 4);
     CHECK(has_no_hole.check_for_holes_in_square_mesh() == false);
 }
-    
+
 TEST_CASE("test detector for square mesh", "[tntn]")
 {
 
     std::vector<Vertex> vertices;
     std::vector<Face> faces;
-    
+
     vertices.push_back({0.0, 0.0, 0.0}); // 0
     vertices.push_back({1.0, 0.0, 0.0}); // 1
     vertices.push_back({1.0, 1.0, 0.0}); // 2
-    
+
     faces.push_back({{0, 1, 2}}); // t0
-    
+
     Mesh non_square;
     non_square.from_decomposed(std::move(vertices), std::move(faces));
     non_square.generate_triangles();
-    
+
     CHECK(non_square.poly_count() == 1);
     CHECK(non_square.is_square() == false);
-    
+
     vertices.clear();
     faces.clear();
-    
+
     vertices.push_back({0.0, 0.0, 0.0}); // 0
     vertices.push_back({1.0, 1.0, 0.0}); // 1
     vertices.push_back({0.0, 1.0, 0.0}); // 2
     vertices.push_back({1.0, 0.0, 0.0}); // 3
-    
+
     faces.push_back({{0, 3, 1}}); // t0
     faces.push_back({{0, 1, 2}}); // t1
-    
+
     Mesh square;
     square.from_decomposed(std::move(vertices), std::move(faces));
     square.generate_triangles();
-    
+
     CHECK(square.poly_count() == 2);
     CHECK(square.is_square() == true);
-    
 }
-    
+
 TEST_CASE("Mesh from triangles", "[tntn]")
 {
     Mesh m;


### PR DESCRIPTION
The code was incorrectly applying `abs` on doubles, therefore I made the compiler happy by using the correct `fabs`.

I also let `clang-format` do its thing...