### PR TITLE
Fixing stack smashing bug due to invalid array access

### DIFF
--- a/src/raster_tools.cpp
+++ b/src/raster_tools.cpp
@@ -220,7 +220,7 @@ void raster_tools::find_minmax(const RasterDouble& raster, double& min_val, doub
 
 /**
 	 Treat raster as a DEM and return 3D bounding box
-       
+
      @return 3d bounding box
 	*/
 BBox3D raster_tools::get_bounding_box3d(const RasterDouble& raster)
@@ -374,7 +374,7 @@ double raster_tools::sample_nearest_valid_avg(const RasterDouble& src,
         const int64_t dest_r = row + y;
         const int64_t dest_c = column + x;
         double z = subsample_raster_3x3(src, no_data_value, w, h, dest_r, dest_c);
-        if(!is_no_data(z, no_data_value))
+        if(!is_no_data(z, no_data_value) && avg_count < MAX_AVERAGING_SAMPLES)
         {
             to_average[avg_count] = z;
             avg_count++;


### PR DESCRIPTION
I was getting the following error with an input DEM: 

```
performing terra meshing...
starting greedy insertion with raster width: 1600, height: 1600
*** stack smashing detected ***: <unknown> terminated
```

Here is the input tif to reproduce.  
[dem.tif.zip](https://github.com/heremaps/tin-terrain/files/3522447/dem.tif.zip)

And you just call it with 

`tin-terrain dem2tin --input dem.tif --output mesh.obj`

This PR should fix this.