### PR TITLE
Removed the specific ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu
 RUN apt-get update
 RUN apt-get --assume-yes install software-properties-common
 RUN apt-get update


### PR DESCRIPTION
Fix #73 Build Error - caused by 'no release file' error and errors:
E: The repository 'http://security.ubuntu.com/ubuntu cosmic-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic-backports Release' does not have a Release file.